### PR TITLE
Close editor on keyup rather than keydown / don't prevent default, fix false positive on UI test

### DIFF
--- a/blockly-core/core/ui/function_editor.js
+++ b/blockly-core/core/ui/function_editor.js
@@ -537,11 +537,9 @@ Blockly.FunctionEditor.prototype.create_ = function() {
   });
 
   // Enable editor close on press of ESC key
-  Blockly.bindEvent_(goog.dom.getDocument().body, 'keydown', this, function(e) {
+  Blockly.bindEvent_(goog.dom.getDocument().body, 'keyup', this, function(e) {
     if (e.keyCode === goog.events.KeyCodes.ESC) {
       this.onClose();
-      e.preventDefault();
-      e.stopPropagation();
     }
   });
 

--- a/dashboard/test/ui/features/functionEditor.feature
+++ b/dashboard/test/ui/features/functionEditor.feature
@@ -23,8 +23,9 @@ Scenario: Opening the function editor and moving an inner block doesn't bump fun
 Scenario: Opening the function editor and hitting the ESC key should close the editor
   When I press SVG selector ".blocklyIconGroup:contains(edit)"
   And I wait to see "#modalEditorClose"
-  And I hold key "ESC"
-  Then element "#modalEditorClose" is hidden
+  And the modal function editor is open
+  Then I press keys ":escape" for element "body"
+  And the modal function editor is closed
 
 @chrome
 Scenario: Opening / closing the function editor, shouldn't be able to connect to invisible child blocks

--- a/dashboard/test/ui/step_definitions/blockly.rb
+++ b/dashboard/test/ui/step_definitions/blockly.rb
@@ -186,6 +186,14 @@ Then /^block "([^"]*)" doesn't have class "(.*?)"$/ do |block_id, className|
   classes.include?(className).should eq false
 end
 
+Then /^the modal function editor is closed$/ do
+  modal_dialog_visible.should eq false
+end
+
+Then /^the modal function editor is open$/ do
+  modal_dialog_visible.should eq true
+end
+
 When(/^I set block "([^"]*)" to have a value of "(.*?)" for title "(.*?)"$/) do |block_id, value, title|
   script = "
     Blockly.mainBlockSpace.getAllBlocks().forEach(function (b) {

--- a/dashboard/test/ui/support/blockly_helpers.rb
+++ b/dashboard/test/ui/support/blockly_helpers.rb
@@ -66,6 +66,10 @@ module BlocklyHelpers
   def get_block_workspace_top(block_id)
     @browser.execute_script("return Blockly.mainBlockSpace.getBlockById(#{block_id}).getRelativeToSurfaceXY().y;")
   end
+
+  def modal_dialog_visible
+    @browser.execute_script("return $('#modalEditorClose :visible').length != 0;")
+  end
 end
 
 World(BlocklyHelpers)


### PR DESCRIPTION
/review @rvarshney 

Making this a PR to @rvarshney's fork rather than sending along each tweak suggestion in the existing PR comments. Feel free to review/merge to your fork, then I can pull in to code-dot-org/staging from your existing PR (which should get updated if this is merged).

# Keyup rather than keydown

In testing I came across an edge case on CS in Algebra levels (e.g. /s/algebra/stage/8/puzzle/6 ) where, with a function with an empty example:

1. closing the modal dialog (keydown) triggers a validation which in turn
2. opens a modal "are you sure?" style popup which when (keyup)
3. closes the modal "are you sure?" popup

Here's a recording of an example, pressing escape over and over (then briefly holding the key, which triggered a bunch of repeated "are you sure?" popups):

![test-dialog-pop](https://cloud.githubusercontent.com/assets/206973/12662375/d18e6e5a-c5d4-11e5-9284-5f33ca817f78.gif)

The fix for that in this PR changes the modal close to happen on keyup which matches the behavior in the confirmation modal.

This also changes the event to not `preventDefault`/`stopPropagation`. Since we don't have access to information about any sort of global modal stack from this context and can't infer what modals might also be open, it seems like a reasonable UX/scope tradeoff to always allow the escape to bubble up.

# UI test tweaks

## Verifying non-visible case

One of the jQuery visibility checks used in the "`and element is visible`" step happens to give a false-negative for the close button, which made the UI test succeed even though the ESC button press didn't actually trigger a close. This explicitly checks for a sub-item being visible, which I confirmed works for the visible/not-visible cases.

## Have UI test use native Selenium escape key

I wasn't able to trigger using jQuery simulate or jQuery synthetic event, so I changed the escape key press to use a Selenium native browser keypress.